### PR TITLE
Additional configs and use official ASCP chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.18 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5 |
-| <a name="requirement_http"></a> [http](#requirement\_http) | >= 2.2.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.11 |
 
 ## Providers
 
@@ -17,8 +15,6 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.18 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.5 |
-| <a name="provider_http"></a> [http](#provider\_http) | >= 2.2.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.11 |
 
 ## Modules
 
@@ -30,22 +26,25 @@
 
 | Name | Type |
 |------|------|
+| [helm_release.ascp](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_manifest.ascp](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [http_http.ascp_manifest](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ascp_manifest_url"></a> [ascp\_manifest\_url](#input\_ascp\_manifest\_url) | ASCP YAML file in the GitHub repo deployment directory | `string` | `"https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml"` | no |
+| <a name="input_affinity"></a> [affinity](#input\_affinity) | Affinity for Secrets Store CSI Driver pods. Prevents the CSI driver from being scheduled on virtual-kubelet nodes by default | `map(any)` | <pre>{<br>  "nodeAffinity": {<br>    "requiredDuringSchedulingIgnoredDuringExecution": {<br>      "nodeSelectorTerms": [<br>        {<br>          "matchExpressions": [<br>            {<br>              "key": "type",<br>              "operator": "NotIn",<br>              "values": [<br>                "virtual-kubelet"<br>              ]<br>            }<br>          ]<br>        }<br>      ]<br>    }<br>  }<br>}</pre> | no |
+| <a name="input_ascp_chart_name"></a> [ascp\_chart\_name](#input\_ascp\_chart\_name) | Name of ASCP chart | `string` | `"csi-secrets-store-provider-aws"` | no |
+| <a name="input_ascp_chart_namespace"></a> [ascp\_chart\_namespace](#input\_ascp\_chart\_namespace) | Namespace to install the ASCP chart into | `string` | `"kube-system"` | no |
+| <a name="input_ascp_chart_repository"></a> [ascp\_chart\_repository](#input\_ascp\_chart\_repository) | Helm repository for the ASCP chart | `string` | `"https://aws.github.io/eks-charts"` | no |
+| <a name="input_ascp_chart_timeout"></a> [ascp\_chart\_timeout](#input\_ascp\_chart\_timeout) | Timeout to wait for the ASCP chart to be deployed. | `number` | `300` | no |
+| <a name="input_ascp_chart_version"></a> [ascp\_chart\_version](#input\_ascp\_chart\_version) | Version of ASCP chart to install. Set to empty to install the latest version | `string` | `"0.0.3"` | no |
+| <a name="input_ascp_release_name"></a> [ascp\_release\_name](#input\_ascp\_release\_name) | ASCP helm release name | `string` | `"csi-secrets-store-provider-aws"` | no |
 | <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Helm chart name to provision | `string` | `"secrets-store-csi-driver"` | no |
 | <a name="input_chart_namespace"></a> [chart\_namespace](#input\_chart\_namespace) | Namespace to install the chart into | `string` | `"kube-system"` | no |
 | <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository for the chart | `string` | `"https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"` | no |
 | <a name="input_chart_timeout"></a> [chart\_timeout](#input\_chart\_timeout) | Timeout to wait for the Chart to be deployed. | `number` | `300` | no |
-| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of Chart to install. Set to empty to install the latest version | `string` | `"1.1.2"` | no |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of Chart to install. Set to empty to install the latest version | `string` | `"1.2.2"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of Kubernetes Cluster | `string` | n/a | yes |
 | <a name="input_create_default_irsa"></a> [create\_default\_irsa](#input\_create\_default\_irsa) | Create default IRSA for service account | `bool` | `true` | no |
 | <a name="input_enableSecretRotation"></a> [enableSecretRotation](#input\_enableSecretRotation) | Enable rotation for secrets | `bool` | `false` | no |
@@ -57,18 +56,106 @@
 | <a name="input_iam_role_permission_boundary"></a> [iam\_role\_permission\_boundary](#input\_iam\_role\_permission\_boundary) | Permission boundary ARN for IAM Role for controller | `string` | `""` | no |
 | <a name="input_iam_role_policy"></a> [iam\_role\_policy](#input\_iam\_role\_policy) | Override the IAM policy for the controller | `string` | `""` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | Tags for IAM Role for controller | `map(string)` | `{}` | no |
-| <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Image repository on Dockerhub | `string` | `"k8s.gcr.io/csi-secrets-store/driver"` | no |
-| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag | `string` | `"v1.1.2"` | no |
+| <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Image repository for the Driver | `string` | `"k8s.gcr.io/csi-secrets-store/driver"` | no |
+| <a name="input_image_repository_crds"></a> [image\_repository\_crds](#input\_image\_repository\_crds) | Image repository for the CRDs | `string` | `"k8s.gcr.io/csi-secrets-store/driver-crds"` | no |
+| <a name="input_image_repository_liveness"></a> [image\_repository\_liveness](#input\_image\_repository\_liveness) | Image repository for the Liveness Probe | `string` | `"k8s.gcr.io/sig-storage/livenessprobe"` | no |
+| <a name="input_image_repository_registrar"></a> [image\_repository\_registrar](#input\_image\_repository\_registrar) | Image repository for the Registrar | `string` | `"k8s.gcr.io/sig-storage/csi-node-driver-registrar"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag for the Driver and CRDs | `string` | `"v1.2.2"` | no |
+| <a name="input_image_tag_liveness"></a> [image\_tag\_liveness](#input\_image\_tag\_liveness) | Image tag fo the LivenessProbe | `string` | `"v2.7.0"` | no |
+| <a name="input_image_tag_registrar"></a> [image\_tag\_registrar](#input\_image\_tag\_registrar) | Image tag | `string` | `"v2.5.1"` | no |
 | <a name="input_max_history"></a> [max\_history](#input\_max\_history) | Max History for Helm | `number` | `20` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace, where the service account want to create | `string` | `"default"` | no |
+| <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for Secrets Store CSI Driver pods | `map(any)` | `{}` | no |
 | <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | OIDC Provider ARN for IRSA | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The AWS region for the kubernetes cluster. Set to use KIAM or kube2iam for example. | `string` | `""` | no |
 | <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Helm release name | `string` | `"secrets-store-csi-driver"` | no |
 | <a name="input_resources_driver"></a> [resources\_driver](#input\_resources\_driver) | Driver Resources | `map(any)` | <pre>{<br>  "limits": {<br>    "cpu": "200m",<br>    "memory": "200Mi"<br>  },<br>  "requests": {<br>    "cpu": "200m",<br>    "memory": "200Mi"<br>  }<br>}</pre> | no |
-| <a name="input_resources_liveness"></a> [resources\_liveness](#input\_resources\_liveness) | LivenessProbe Resources | `map(any)` | <pre>{<br>  "limits": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  },<br>  "requests": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  }<br>}</pre> | no |
+| <a name="input_resources_liveness"></a> [resources\_liveness](#input\_resources\_liveness) | Liveness Probe Resources | `map(any)` | <pre>{<br>  "limits": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  },<br>  "requests": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  }<br>}</pre> | no |
 | <a name="input_resources_registrar"></a> [resources\_registrar](#input\_resources\_registrar) | Registrar Resources | `map(any)` | <pre>{<br>  "limits": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  },<br>  "requests": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  }<br>}</pre> | no |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | Name of service account to create. Not generated | `string` | `"csi-secrets-store-provider-aws"` | no |
 | <a name="input_syncSecretEnabled"></a> [syncSecretEnabled](#input\_syncSecretEnabled) | Sync with kubernetes secrets | `bool` | `false` | no |
+| <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for Secrets Store CSI Driver pods | `list(map(string))` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
+| <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
+| <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |
+ ⎈antares-dev  🌩 default  ~/terraform-aws-secrets-store-csi   main  terraform-docs md .
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.18 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.5 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_secrets_manager_role"></a> [secrets\_manager\_role](#module\_secrets\_manager\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 4.21.1 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.ascp](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_affinity"></a> [affinity](#input\_affinity) | Affinity for Secrets Store CSI Driver pods. Prevents the CSI driver from being scheduled on virtual-kubelet nodes by default | `map(any)` | <pre>{<br>  "nodeAffinity": {<br>    "requiredDuringSchedulingIgnoredDuringExecution": {<br>      "nodeSelectorTerms": [<br>        {<br>          "matchExpressions": [<br>            {<br>              "key": "type",<br>              "operator": "NotIn",<br>              "values": [<br>                "virtual-kubelet"<br>              ]<br>            }<br>          ]<br>        }<br>      ]<br>    }<br>  }<br>}</pre> | no |
+| <a name="input_ascp_chart_name"></a> [ascp\_chart\_name](#input\_ascp\_chart\_name) | Name of ASCP chart | `string` | `"csi-secrets-store-provider-aws"` | no |
+| <a name="input_ascp_chart_namespace"></a> [ascp\_chart\_namespace](#input\_ascp\_chart\_namespace) | Namespace to install the ASCP chart into | `string` | `"kube-system"` | no |
+| <a name="input_ascp_chart_repository"></a> [ascp\_chart\_repository](#input\_ascp\_chart\_repository) | Helm repository for the ASCP chart | `string` | `"https://aws.github.io/eks-charts"` | no |
+| <a name="input_ascp_chart_timeout"></a> [ascp\_chart\_timeout](#input\_ascp\_chart\_timeout) | Timeout to wait for the ASCP chart to be deployed. | `number` | `300` | no |
+| <a name="input_ascp_chart_version"></a> [ascp\_chart\_version](#input\_ascp\_chart\_version) | Version of ASCP chart to install. Set to empty to install the latest version | `string` | `"0.0.3"` | no |
+| <a name="input_ascp_release_name"></a> [ascp\_release\_name](#input\_ascp\_release\_name) | ASCP helm release name | `string` | `"csi-secrets-store-provider-aws"` | no |
+| <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Helm chart name to provision | `string` | `"secrets-store-csi-driver"` | no |
+| <a name="input_chart_namespace"></a> [chart\_namespace](#input\_chart\_namespace) | Namespace to install the chart into | `string` | `"kube-system"` | no |
+| <a name="input_chart_repository"></a> [chart\_repository](#input\_chart\_repository) | Helm repository for the chart | `string` | `"https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"` | no |
+| <a name="input_chart_timeout"></a> [chart\_timeout](#input\_chart\_timeout) | Timeout to wait for the Chart to be deployed. | `number` | `300` | no |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | Version of Chart to install. Set to empty to install the latest version | `string` | `"1.2.2"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of Kubernetes Cluster | `string` | n/a | yes |
+| <a name="input_create_default_irsa"></a> [create\_default\_irsa](#input\_create\_default\_irsa) | Create default IRSA for service account | `bool` | `true` | no |
+| <a name="input_enableSecretRotation"></a> [enableSecretRotation](#input\_enableSecretRotation) | Enable rotation for secrets | `bool` | `false` | no |
+| <a name="input_external_secrets_secrets_manager_arns"></a> [external\_secrets\_secrets\_manager\_arns](#input\_external\_secrets\_secrets\_manager\_arns) | List of Secrets Manager ARNs that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br>  "arn:aws:secretsmanager:*:*:secret:*"<br>]</pre> | no |
+| <a name="input_external_secrets_ssm_parameter_arns"></a> [external\_secrets\_ssm\_parameter\_arns](#input\_external\_secrets\_ssm\_parameter\_arns) | List of Systems Manager Parameter ARNs that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br>  "arn:aws:ssm:*:*:parameter/*"<br>]</pre> | no |
+| <a name="input_iam_role_description"></a> [iam\_role\_description](#input\_iam\_role\_description) | Description for IAM role for controller | `string` | `"Used by AWS Load Balancer Controller for EKS"` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of IAM role for controller | `string` | `""` | no |
+| <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM Role path for controller | `string` | `""` | no |
+| <a name="input_iam_role_permission_boundary"></a> [iam\_role\_permission\_boundary](#input\_iam\_role\_permission\_boundary) | Permission boundary ARN for IAM Role for controller | `string` | `""` | no |
+| <a name="input_iam_role_policy"></a> [iam\_role\_policy](#input\_iam\_role\_policy) | Override the IAM policy for the controller | `string` | `""` | no |
+| <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | Tags for IAM Role for controller | `map(string)` | `{}` | no |
+| <a name="input_image_repository"></a> [image\_repository](#input\_image\_repository) | Image repository for the Driver | `string` | `"k8s.gcr.io/csi-secrets-store/driver"` | no |
+| <a name="input_image_repository_crds"></a> [image\_repository\_crds](#input\_image\_repository\_crds) | Image repository for the CRDs | `string` | `"k8s.gcr.io/csi-secrets-store/driver-crds"` | no |
+| <a name="input_image_repository_liveness"></a> [image\_repository\_liveness](#input\_image\_repository\_liveness) | Image repository for the Liveness Probe | `string` | `"k8s.gcr.io/sig-storage/livenessprobe"` | no |
+| <a name="input_image_repository_registrar"></a> [image\_repository\_registrar](#input\_image\_repository\_registrar) | Image repository for the Registrar | `string` | `"k8s.gcr.io/sig-storage/csi-node-driver-registrar"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag for the Driver and CRDs | `string` | `"v1.2.2"` | no |
+| <a name="input_image_tag_liveness"></a> [image\_tag\_liveness](#input\_image\_tag\_liveness) | Image tag fo the LivenessProbe | `string` | `"v2.7.0"` | no |
+| <a name="input_image_tag_registrar"></a> [image\_tag\_registrar](#input\_image\_tag\_registrar) | Image tag | `string` | `"v2.5.1"` | no |
+| <a name="input_max_history"></a> [max\_history](#input\_max\_history) | Max History for Helm | `number` | `20` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace, where the service account want to create | `string` | `"default"` | no |
+| <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for Secrets Store CSI Driver pods | `map(any)` | `{}` | no |
+| <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | OIDC Provider ARN for IRSA | `string` | n/a | yes |
+| <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Helm release name | `string` | `"secrets-store-csi-driver"` | no |
+| <a name="input_resources_driver"></a> [resources\_driver](#input\_resources\_driver) | Driver Resources | `map(any)` | <pre>{<br>  "limits": {<br>    "cpu": "200m",<br>    "memory": "200Mi"<br>  },<br>  "requests": {<br>    "cpu": "200m",<br>    "memory": "200Mi"<br>  }<br>}</pre> | no |
+| <a name="input_resources_liveness"></a> [resources\_liveness](#input\_resources\_liveness) | Liveness Probe Resources | `map(any)` | <pre>{<br>  "limits": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  },<br>  "requests": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  }<br>}</pre> | no |
+| <a name="input_resources_registrar"></a> [resources\_registrar](#input\_resources\_registrar) | Registrar Resources | `map(any)` | <pre>{<br>  "limits": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  },<br>  "requests": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  }<br>}</pre> | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | Name of service account to create. Not generated | `string` | `"csi-secrets-store-provider-aws"` | no |
+| <a name="input_syncSecretEnabled"></a> [syncSecretEnabled](#input\_syncSecretEnabled) | Sync with kubernetes secrets | `bool` | `false` | no |
+| <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for Secrets Store CSI Driver pods | `list(map(string))` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.18 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.18 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.5 |
 
 ## Modules

--- a/data.tf
+++ b/data.tf
@@ -1,9 +1,0 @@
-data "aws_region" "current" {
-}
-
-data "aws_caller_identity" "current" {
-}
-
-data "http" "ascp_manifest" {
-  url = "https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml"
-}

--- a/main.tf
+++ b/main.tf
@@ -16,9 +16,11 @@ locals {
     resources_registrar = jsonencode(var.resources_registrar)
     resources_liveness  = jsonencode(var.resources_liveness)
 
-    affinity      = jsonencode(var.affinity)
-    node_selector = jsonencode(var.node_selector)
-    tolerations   = jsonencode(var.tolerations)
+    affinity        = jsonencode(var.affinity)
+    node_selector   = jsonencode(var.node_selector)
+    tolerations     = jsonencode(var.tolerations)
+    pod_labels      = jsonencode(var.pod_labels)
+    pod_annotations = jsonencode(var.pod_annotations)
 
     syncSecretEnabled    = var.syncSecretEnabled
     enableSecretRotation = var.enableSecretRotation

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,15 @@ locals {
   service_account_name = var.service_account_name
 
   secrets_store_csi_values = {
-    image_repository = var.image_repository
-    image_tag        = var.image_tag
+    image_repository      = var.image_repository
+    image_repository_crds = var.image_repository_crds
+    image_tag             = var.image_tag
+
+    image_repository_registrar = var.image_repository_registrar
+    image_tag_registrar        = var.image_tag_registrar
+
+    image_repository_liveness = var.image_repository_liveness
+    image_tag_liveness        = var.image_tag_liveness
 
     resources_driver    = jsonencode(var.resources_driver)
     resources_registrar = jsonencode(var.resources_registrar)
@@ -41,9 +48,9 @@ resource "helm_release" "ascp" {
   namespace  = var.ascp_chart_namespace
 
   max_history = var.max_history
-  timeout     = var.chart_timeout
+  timeout     = var.ascp_chart_timeout
 
   values = [
-    templatefile("${path.module}/templates/ascp.yaml", local.values),
+    templatefile("${path.module}/templates/ascp.yaml", local.ascp_values),
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,21 @@ locals {
     enableSecretRotation = var.enableSecretRotation
   }
 
-  ascp_values = {}
+  ascp_values = {
+    image_registry   = var.ascp_image_registry
+    image_repository = var.ascp_image_repository
+    image_tag        = var.ascp_image_tag
+
+    node_selector = jsonencode(var.ascp_node_selector)
+    tolerations   = jsonencode(var.ascp_tolerations)
+    resources     = jsonencode(var.ascp_resources)
+
+    pod_labels      = jsonencode(var.ascp_pod_labels)
+    pod_annotations = jsonencode(var.ascp_pod_annotations)
+
+    service_account_name = local.service_account_name
+    priority_class_name  = var.ascp_priority_class_name
+  }
 }
 
 resource "helm_release" "release" {

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,8 @@ locals {
     syncSecretEnabled    = var.syncSecretEnabled
     enableSecretRotation = var.enableSecretRotation
   }
+
+  ascp_values = {}
 }
 
 resource "helm_release" "release" {

--- a/templates/ascp.yaml
+++ b/templates/ascp.yaml
@@ -1,0 +1,41 @@
+imagePullSecrets: []
+
+image:
+  registry: public.ecr.aws
+  repository: aws-secrets-manager/secrets-store-csi-driver-provider-aws
+  ## defaults to app.Version
+  tag:
+  pullPolicy: IfNotPresent
+
+nodeSelector: {}
+tolerations: []
+
+port: 8989
+
+privileged: false
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 100Mi
+  limits:
+    cpu: 50m
+    memory: 100Mi
+
+podLabels: {}
+podAnnotations: {}
+
+updateStrategy:
+  type: RollingUpdate
+
+secrets-store-csi-driver:
+  install: false
+
+## Install default service account
+rbac:
+  install: true
+  pspEnabled: false
+  serviceAccount:
+    name:
+
+priorityClassName: ""

--- a/templates/ascp.yaml
+++ b/templates/ascp.yaml
@@ -1,29 +1,19 @@
 imagePullSecrets: []
 
 image:
-  registry: public.ecr.aws
-  repository: aws-secrets-manager/secrets-store-csi-driver-provider-aws
+  registry: ${image_registry}
+  repository: ${image_repository}
   ## defaults to app.Version
-  tag:
+  tag: ${image_tag}
   pullPolicy: IfNotPresent
 
-nodeSelector: {}
-tolerations: []
+nodeSelector: ${node_selector}
+tolerations: ${tolerations}
 
-port: 8989
+resources: ${resources}
 
-privileged: false
-
-resources:
-  requests:
-    cpu: 50m
-    memory: 100Mi
-  limits:
-    cpu: 50m
-    memory: 100Mi
-
-podLabels: {}
-podAnnotations: {}
+podLabels: ${pod_labels}
+podAnnotations: ${pod_annotations}
 
 updateStrategy:
   type: RollingUpdate
@@ -36,6 +26,6 @@ rbac:
   install: true
   pspEnabled: false
   serviceAccount:
-    name:
+    name: ${service_account_name}
 
-priorityClassName: ""
+priorityClassName: "${priority_class_name}"

--- a/templates/secrets_store_csi.yaml
+++ b/templates/secrets_store_csi.yaml
@@ -7,28 +7,19 @@ linux:
 
   crds:
     image:
-      repository: ${image_repository}-crds
+      repository: ${image_repository_crds}
       tag: ${image_tag}
       pullPolicy: IfNotPresent
     annotations: {}
 
-  ## Prevent the CSI driver from being scheduled on virtual-kubelet nodes
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: type
-                operator: NotIn
-                values:
-                  - virtual-kubelet
+  affinity: ${affinity}
 
   driver:
     resources: ${resources_driver}
 
   registrarImage:
-    repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    tag: v2.5.0
+    repository: ${image_repository_registrar}
+    tag: ${image_tag_registrar}
     pullPolicy: IfNotPresent
 
   registrar:
@@ -36,8 +27,8 @@ linux:
     logVerbosity: 5
 
   livenessProbeImage:
-    repository: k8s.gcr.io/sig-storage/livenessprobe
-    tag: v2.6.0
+    repository: ${image_repository_liveness_probe}
+    tag: ${image_tag_liveness_probe}
     pullPolicy: IfNotPresent
 
   livenessProbe:
@@ -52,8 +43,8 @@ linux:
   providersDir: /etc/kubernetes/secrets-store-csi-providers
   additionalProvidersDirs:
     - /var/run/secrets-store-csi-providers
-  nodeSelector: {}
-  tolerations: []
+  nodeSelector: ${node_selector}
+  tolerations: ${tolerations}
   metricsAddr: ":8095"
   env: []
   priorityClassName: ""

--- a/templates/secrets_store_csi.yaml
+++ b/templates/secrets_store_csi.yaml
@@ -27,8 +27,8 @@ linux:
     logVerbosity: 5
 
   livenessProbeImage:
-    repository: ${image_repository_liveness_probe}
-    tag: ${image_tag_liveness_probe}
+    repository: ${image_repository_liveness}
+    tag: ${image_tag_liveness}
     pullPolicy: IfNotPresent
 
   livenessProbe:

--- a/templates/secrets_store_csi.yaml
+++ b/templates/secrets_store_csi.yaml
@@ -49,8 +49,8 @@ linux:
   env: []
   priorityClassName: ""
   daemonsetAnnotations: {}
-  podAnnotations: {}
-  podLabels: {}
+  podAnnotations: ${pod_annotations}
+  podLabels: ${pod_labels}
 
   # volumes is a list of volumes made available to secrets store csi driver.
   volumes: null

--- a/variables.tf
+++ b/variables.tf
@@ -172,6 +172,18 @@ variable "tolerations" {
   default     = []
 }
 
+variable "pod_labels" {
+  description = "Labels for Secrets Store CSI Driver pods"
+  type        = map(any)
+  default     = {}
+}
+
+variable "pod_annotations" {
+  description = "Annotations for Secrets Store CSI Driver pods"
+  type        = map(any)
+  default     = {}
+}
+
 variable "syncSecretEnabled" {
   description = "Sync with kubernetes secrets"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -3,12 +3,6 @@ variable "cluster_name" {
   type        = string
 }
 
-variable "region" {
-  description = "The AWS region for the kubernetes cluster. Set to use KIAM or kube2iam for example."
-  type        = string
-  default     = ""
-}
-
 variable "release_name" {
   description = "Helm release name"
   type        = string
@@ -30,7 +24,7 @@ variable "chart_repository" {
 variable "chart_version" {
   description = "Version of Chart to install. Set to empty to install the latest version"
   type        = string
-  default     = "1.1.2"
+  default     = "1.2.2"
 }
 
 variable "chart_namespace" {
@@ -56,15 +50,21 @@ variable "max_history" {
 ########################
 
 variable "image_repository" {
-  description = "Image repository on Dockerhub"
+  description = "Image repository for the Driver"
   type        = string
   default     = "k8s.gcr.io/csi-secrets-store/driver"
 }
 
-variable "image_tag" {
-  description = "Image tag"
+variable "image_repository_crds" {
+  description = "Image repository for the CRDs"
   type        = string
-  default     = "v1.1.2"
+  default     = "k8s.gcr.io/csi-secrets-store/driver-crds"
+}
+
+variable "image_tag" {
+  description = "Image tag for the Driver and CRDs"
+  type        = string
+  default     = "v1.2.2"
 }
 
 variable "resources_driver" {
@@ -82,6 +82,18 @@ variable "resources_driver" {
   }
 }
 
+variable "image_repository_registrar" {
+  description = "Image repository for the Registrar"
+  type        = string
+  default     = "k8s.gcr.io/sig-storage/csi-node-driver-registrar"
+}
+
+variable "image_tag_registrar" {
+  description = "Image tag"
+  type        = string
+  default     = "v2.5.0"
+}
+
 variable "resources_registrar" {
   description = "Registrar Resources"
   type        = map(any)
@@ -97,8 +109,20 @@ variable "resources_registrar" {
   }
 }
 
+variable "image_repository_liveness" {
+  description = "Image repository for the Liveness Probe"
+  type        = string
+  default     = "k8s.gcr.io/sig-storage/livenessprobe"
+}
+
+variable "image_tag_liveness" {
+  description = "Image tag fo the LivenessProbe"
+  type        = string
+  default     = "v2.6.0"
+}
+
 variable "resources_liveness" {
-  description = "LivenessProbe Resources"
+  description = "Liveness Probe Resources"
   type        = map(any)
   default = {
     requests = {
@@ -110,6 +134,43 @@ variable "resources_liveness" {
       memory = "100Mi"
     }
   }
+}
+
+variable "affinity" {
+  description = "Affinity for Secrets Store CSI Driver pods. Prevents the CSI driver from being scheduled on virtual-kubelet nodes by default"
+  type        = map(any)
+
+  default = {
+    nodeAffinity = {
+      requiredDuringSchedulingIgnoredDuringExecution = {
+        nodeSelectorTerms = [
+          {
+            matchExpressions = [
+              {
+                key      = "type"
+                operator = "NotIn"
+                values = [
+                  "virtual-kubelet"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+
+variable "node_selector" {
+  description = "Node selector for Secrets Store CSI Driver pods"
+  type        = map(any)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Tolerations for Secrets Store CSI Driver pods"
+  type        = list(map(string))
+  default     = []
 }
 
 variable "syncSecretEnabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -223,6 +223,69 @@ variable "ascp_chart_timeout" {
   default     = 300
 }
 
+variable "ascp_image_registry" {
+  description = "Image registry of the ASCP"
+  type        = string
+  default     = "public.ecr.aws"
+}
+
+variable "ascp_image_repository" {
+  description = "Image repository of the ASCP"
+  type        = string
+  default     = "aws-secrets-manager/secrets-store-csi-driver-provider-aws"
+}
+
+variable "ascp_image_tag" {
+  description = "Image tag of the ASCP"
+  type        = string
+  default     = "1.0.r2-6-gee95299-2022.04.14.21.07"
+}
+
+variable "ascp_node_selector" {
+  description = "Node selector for ASCP pods"
+  type        = map(any)
+  default     = {}
+}
+
+variable "ascp_tolerations" {
+  description = "Tolerations for ASCP pods"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ascp_resources" {
+  description = "ASCP container rsources"
+  type        = map(any)
+  default = {
+    requests = {
+      cpu    = "50m"
+      memory = "100Mi"
+    }
+    limits = {
+      cpu    = "50m"
+      memory = "100Mi"
+    }
+  }
+}
+
+variable "ascp_pod_labels" {
+  description = "Labels for ASCP pods"
+  type        = map(any)
+  default     = {}
+}
+
+variable "ascp_pod_annotations" {
+  description = "Annotations for ASCP pods"
+  type        = map(any)
+  default     = {}
+}
+
+variable "ascp_priority_class_name" {
+  description = "Priority class name for ASCP pods"
+  type        = string
+  default     = ""
+}
+
 ########################
 # IAM Role
 ########################

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,15 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "max_history" {
+  description = "Max History for Helm"
+  type        = number
+  default     = 20
+}
+
+#########################################
+# Secrets Store CSI Driver Chart Values
+#########################################
 variable "release_name" {
   description = "Helm release name"
   type        = string
@@ -38,16 +47,6 @@ variable "chart_timeout" {
   type        = number
   default     = 300
 }
-
-variable "max_history" {
-  description = "Max History for Helm"
-  type        = number
-  default     = 20
-}
-
-########################
-# Chart Values
-########################
 
 variable "image_repository" {
   description = "Image repository for the Driver"
@@ -91,7 +90,7 @@ variable "image_repository_registrar" {
 variable "image_tag_registrar" {
   description = "Image tag"
   type        = string
-  default     = "v2.5.0"
+  default     = "v2.5.1"
 }
 
 variable "resources_registrar" {
@@ -118,7 +117,7 @@ variable "image_repository_liveness" {
 variable "image_tag_liveness" {
   description = "Image tag fo the LivenessProbe"
   type        = string
-  default     = "v2.6.0"
+  default     = "v2.7.0"
 }
 
 variable "resources_liveness" {
@@ -185,14 +184,43 @@ variable "enableSecretRotation" {
   default     = false
 }
 
-###########
-## ASCP ###
-###########
-
-variable "ascp_manifest_url" {
-  description = "ASCP YAML file in the GitHub repo deployment directory"
+###########################
+## ASCP Helm Chart Values
+###########################
+variable "ascp_release_name" {
+  description = "ASCP helm release name"
   type        = string
-  default     = "https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml"
+  default     = "csi-secrets-store-provider-aws"
+}
+
+variable "ascp_chart_name" {
+  description = "Name of ASCP chart"
+  type        = string
+  default     = "csi-secrets-store-provider-aws"
+}
+
+variable "ascp_chart_repository" {
+  description = "Helm repository for the ASCP chart"
+  type        = string
+  default     = "https://aws.github.io/eks-charts"
+}
+
+variable "ascp_chart_version" {
+  description = "Version of ASCP chart to install. Set to empty to install the latest version"
+  type        = string
+  default     = "0.0.3"
+}
+
+variable "ascp_chart_namespace" {
+  description = "Namespace to install the ASCP chart into"
+  type        = string
+  default     = "kube-system"
+}
+
+variable "ascp_chart_timeout" {
+  description = "Timeout to wait for the ASCP chart to be deployed."
+  type        = number
+  default     = 300
 }
 
 ########################

--- a/versions.tf
+++ b/versions.tf
@@ -9,13 +9,5 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.5"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.11"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = ">= 2.2.0"
-    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,6 @@
 terraform {
   required_version = ">= 1.0"
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.18"
-    }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.5"


### PR DESCRIPTION
## What
Introduced additions and changes so that Secrets Store CSI driver and ASCP is more configurable

Please note that this would be a breaking change due to the switch from `kubernetes_manifest` resources to `helm_release` for ASCP.

## How
- [x] Update Secrets Store CSI driver components and chart to latest version
- [x] Allow additional config (such as affinity, toleration and nodeselector)
- [x] Remove unused variables and data sources
- [x] Use official helm chart for ASCP so it is more configurable

